### PR TITLE
Tie glyphs:compile to assets:precompile

### DIFF
--- a/lib/tasks/glyphs.rake
+++ b/lib/tasks/glyphs.rake
@@ -17,3 +17,7 @@ namespace :glyphs do
     %x{rm app/assets/stylesheets/components/_fontcustom.scss.bak}
   end
 end
+
+namespace :assets do
+  task :precompile => 'glyphs:compile'
+end


### PR DESCRIPTION
Run `glyphs:compile` before `assets:precompile` so that it's a one-command affair.
